### PR TITLE
Fix Github link

### DIFF
--- a/app/views/welcome/contact.html.slim
+++ b/app/views/welcome/contact.html.slim
@@ -51,7 +51,7 @@
                 i.fa.fa-instagram
                 i.fa.fa-instagram
             li
-              = link_to 'ttps://github.com/orgs/cesium', class: 'social-icon-lg si-border si-github'
+              = link_to 'https://github.com/orgs/cesium', class: 'social-icon-lg si-border si-github'
                 i.fa.fa-github
                 i.fa.fa-github
 


### PR DESCRIPTION
Small typo in link's protocol that inhibits visitors to reach Cesium's github profile.