### PR TITLE
Move organization info links to main navbar

### DIFF
--- a/app/views/layouts/lp/_navbar.html.slim
+++ b/app/views/layouts/lp/_navbar.html.slim
@@ -10,15 +10,10 @@
 
     .navbar-collapse.collapse
       ul.nav.navbar-nav.navbar-right
-        li.dropdown
-          a.dropdown-toggle data-toggle="dropdown" href="#"
-            | CESIUM
-            i.fa.fa-angle-down<
-          ul.dropdown-menu role="menu"
-            li
-              = link_to 'Apresentação', about_path
-            li
-              = link_to 'Equipa', team_path
+        li
+          = link_to 'Sobre', about_path
+        li
+          = link_to 'Equipa', team_path
         / li
         /   = link_to 'NOTÍCIAS', news_path
         / li


### PR DESCRIPTION
The existing dropdown that contains links to more information is unnecessary since we are already in Cesium's context. Also, those info links in main navbar are more visible to users this way.