### PR TITLE
Update Capistrano config removing bin from :linked_dirs.

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -26,7 +26,7 @@ set :branch, ENV['BRANCH'] if ENV['BRANCH']
 set :linked_files, %w{config/database.yml}
 
 # Default value for linked_dirs is []
-set :linked_dirs, %w{bin log tmp/pids tmp/cache tmp/sockets vendor/bundle public/system}
+set :linked_dirs, %w{log tmp/pids tmp/cache tmp/sockets vendor/bundle public/system}
 
 # Default value for default_env is {}
 # set :default_env, { path: "/opt/ruby/bin:$PATH" }


### PR DESCRIPTION
* This fixes the issue where the contents of the bin folder (the
rails, bundle, rake, ... scripts) were not deployed to the server.
Without the contents of this folder it is not possible to run the
typical rails commands on the server.