### PR TITLE
Add Member Model

### DIFF
--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -1,3 +1,12 @@
-class Member < User
-  has_one :payment, foreign_key: :user_id, dependent: :destroy
+class Member < ActiveRecord::Base
+  has_one :responsible_member, class_name: 'Member'
+  has_one :user
+  has_many :terms
+  has_many :roles, through: :term
+
+  validates :account_number,
+    length: { maximum: 10 },
+    format: { with: /[0-9]*/ }
+  validates :student_id,
+    length: { maximum: 10 }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,22 +1,11 @@
 class User < ActiveRecord::Base
-  scope :members, -> { where(type: "Member") }
-  scope :buddies, -> { where(type: "Buddy") }
-
   has_many :payments
-  has_many :terms
-  has_many :roles, through: :term
   has_many :registrations
+  belongs_to :member
 
-  validates :account_number,
-    length: { maximum: 10 },
-    format: { with: /[0-9]*/ }
-  validates :student_id,
-    length: { maximum: 10 }
   validates :name,
     presence: true,
     length: { maximum: 75 }
-  validates :city,
-    length: { maximum: 30 }
   validates :phone_number,
     length: { maximum: 15 },
     format: { with: /[0-9]*/ }

--- a/db/migrate/20170222220121_create_members.rb
+++ b/db/migrate/20170222220121_create_members.rb
@@ -1,0 +1,17 @@
+class CreateMembers < ActiveRecord::Migration
+  def change
+    create_table :members do |t|
+      t.integer :member_id
+      t.string :name
+      t.string :phone
+      t.string :address
+      t.string :email
+      t.date :birthdate
+      t.string :course
+      t.string :student_id
+      t.boolean :paid
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20170227171330_remove_city_from_user.rb
+++ b/db/migrate/20170227171330_remove_city_from_user.rb
@@ -1,0 +1,5 @@
+class RemoveCityFromUser < ActiveRecord::Migration
+  def change
+    remove_column :users, :city
+  end
+end

--- a/db/migrate/20170227172551_remove_student_id_from_member.rb
+++ b/db/migrate/20170227172551_remove_student_id_from_member.rb
@@ -1,0 +1,5 @@
+class RemoveStudentIdFromMember < ActiveRecord::Migration
+  def change
+    remove_column :members, :student_id
+  end
+end

--- a/db/migrate/20170227172642_remove_phone_from_member.rb
+++ b/db/migrate/20170227172642_remove_phone_from_member.rb
@@ -1,0 +1,5 @@
+class RemovePhoneFromMember < ActiveRecord::Migration
+  def change
+    remove_column :members, :phone
+  end
+end

--- a/db/migrate/20170301203051_remove_account_number_and_student_id_from_user.rb
+++ b/db/migrate/20170301203051_remove_account_number_and_student_id_from_user.rb
@@ -1,0 +1,6 @@
+class RemoveAccountNumberAndStudentIdFromUser < ActiveRecord::Migration
+  def change
+    remove_column :users, :account_number
+    remove_column :users, :student_id
+  end
+end

--- a/db/migrate/20170301203131_add_account_number_and_student_id_to_member.rb
+++ b/db/migrate/20170301203131_add_account_number_and_student_id_to_member.rb
@@ -1,0 +1,6 @@
+class AddAccountNumberAndStudentIdToMember < ActiveRecord::Migration
+  def change
+    add_column :members, :account_number, :string, default: ""
+    add_column :members, :student_id, :string, default: ""
+  end
+end

--- a/db/migrate/20170301203910_remove_user_type_from_user.rb
+++ b/db/migrate/20170301203910_remove_user_type_from_user.rb
@@ -1,0 +1,5 @@
+class RemoveUserTypeFromUser < ActiveRecord::Migration
+  def change
+    remove_column :users, :user_type
+  end
+end

--- a/db/migrate/20170301204142_add_is_buddy_to_member.rb
+++ b/db/migrate/20170301204142_add_is_buddy_to_member.rb
@@ -1,0 +1,5 @@
+class AddIsBuddyToMember < ActiveRecord::Migration
+  def change
+    add_column :members, :is_buddy, :boolean, defaul: false
+  end
+end

--- a/db/migrate/20170301204224_remove_name_from_member.rb
+++ b/db/migrate/20170301204224_remove_name_from_member.rb
@@ -1,0 +1,5 @@
+class RemoveNameFromMember < ActiveRecord::Migration
+  def change
+    remove_column :members, :name
+  end
+end

--- a/db/migrate/20170301205015_remove_admin_from_user.rb
+++ b/db/migrate/20170301205015_remove_admin_from_user.rb
@@ -1,0 +1,5 @@
+class RemoveAdminFromUser < ActiveRecord::Migration
+  def change
+    remove_column :users, :admin
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170220151120) do
+ActiveRecord::Schema.define(version: 20170301205015) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -52,6 +52,20 @@ ActiveRecord::Schema.define(version: 20170220151120) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "members", force: :cascade do |t|
+    t.integer  "member_id"
+    t.string   "address"
+    t.string   "email"
+    t.date     "birthdate"
+    t.string   "course"
+    t.boolean  "paid"
+    t.datetime "created_at",                  null: false
+    t.datetime "updated_at",                  null: false
+    t.string   "account_number", default: ""
+    t.string   "student_id",     default: ""
+    t.boolean  "is_buddy"
+  end
+
   create_table "payments", force: :cascade do |t|
     t.date     "date"
     t.decimal  "value",      precision: 8, scale: 2
@@ -85,16 +99,11 @@ ActiveRecord::Schema.define(version: 20170220151120) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.string   "account_number",   limit: 10, default: ""
-    t.string   "student_id",       limit: 10
     t.string   "name",             limit: 75
-    t.string   "city",             limit: 30
     t.string   "phone_number",     limit: 15, default: ""
-    t.string   "user_type"
-    t.datetime "created_at",                                  null: false
-    t.datetime "updated_at",                                  null: false
+    t.datetime "created_at",                               null: false
+    t.datetime "updated_at",                               null: false
     t.string   "email"
-    t.boolean  "admin",                       default: false, null: false
     t.string   "provider"
     t.string   "uid"
     t.string   "oauth_token"
@@ -102,8 +111,6 @@ ActiveRecord::Schema.define(version: 20170220151120) do
     t.string   "image"
   end
 
-  add_index "users", ["account_number"], name: "index_users_on_account_number", unique: true, using: :btree
   add_index "users", ["email"], name: "index_users_on_email", using: :btree
-  add_index "users", ["student_id"], name: "index_users_on_student_id", unique: true, using: :btree
 
 end

--- a/spec/factories/members.rb
+++ b/spec/factories/members.rb
@@ -1,0 +1,14 @@
+FactoryGirl.define do
+  factory :member do
+    member_id 1
+name "MyString"
+phone "MyString"
+address "MyString"
+email "MyString"
+birthdate "2017-02-22"
+course "MyString"
+student_id "MyString"
+paid false
+  end
+
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -17,10 +17,4 @@ FactoryGirl.define do
     email { Faker::Internet.free_email(name) }
     password { Faker::Internet.password }
   end
-
-  factory :member, class: Member, parent: :user do
-  end
-
-  factory :buddy, class: Buddy, parent: :user do
-  end
 end

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Member, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
@martinhoaragao This is not finished yet, I'm opening a PR because I need your opinion on some questions. If you can check the current attributes for the Member model, notice that `has_one :responsible_member, class_name: 'Member'` referes to the member which registered/added the member (just like we have in our spreadsheet). I've also added `belongs_to :member` in the User model so later we can use something like `current_user.member`.

After checking that out do you think there's still need for `account_number`, `student_id, `city` and `phone_number` in the users table?

I would also suggest moving `user_type` from User to Member and changing it to `member_type`. While we're at it I would also think that it would be nice to have `admin` on the Member side, considering a user needs to be a member in order to be and admin.