### PR TITLE
Fix dotenv in staging and production.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,8 +28,9 @@ gem 'omniauth-google-oauth2'
 
 gem 'cancancan'
 
+gem 'dotenv-rails'
+
 group :development, :test do
-  gem 'dotenv-rails'
   gem 'therubyracer', platforms: :ruby
   gem 'thin'
 


### PR DESCRIPTION
Environment variables weren't being loaded from the .env file because the `dotenv-rails` gem was only in the `:development` and `:test` group in the Gemfile.