### PR TITLE
Move .env to capistrano's shared and update .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@
 # In order for the webapp to work correctly create your own .env file and fill
 # the credentials that you can see below.
 
+ANALYTICS_TRACKING_ID=[YOUR_ANALYTICS_TRACKING_ID]
 FACEBOOK_APP_ID=[YOUR_FACEBOOK_APP_ID]
 FACEBOOK_APP_SECRET=[YOUR_FACEBOOK_APP_SECRET]
 GITHUB_APP_ID=[YOUR_GITHUB_APP_ID]

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -23,7 +23,7 @@ set :branch, ENV['BRANCH'] if ENV['BRANCH']
 # set :pty, true
 
 # Default value for :linked_files is []
-set :linked_files, %w{config/database.yml}
+set :linked_files, %w{.env config/database.yml}
 
 # Default value for linked_dirs is []
 set :linked_dirs, %w{log tmp/pids tmp/cache tmp/sockets vendor/bundle public/system}


### PR DESCRIPTION
Move envs to shared file through Capistrano

Previously the .env file would have to be restored after each deployment. 
Moving it to the capistrano’s shared folder simplifies the process.
