### PR TITLE
Improve Activity Registrations

### DIFF
--- a/app/controllers/activities/registrations_controller.rb
+++ b/app/controllers/activities/registrations_controller.rb
@@ -20,6 +20,13 @@ class Activities::RegistrationsController < ApplicationController
       .find_by(user_id: registration_params[:participant_id])
     registration.update_attribute(:confirmed, !registration.confirmed)
 
+    if registration.confirmed
+      flash[:success] =
+        "Confirmed #{User.find(registration_params[:participant_id]).name}!"
+    else
+      flash[:alert] =
+        "Canceled #{User.find(registration_params[:participant_id]).name} confirmation!"
+    end
     redirect_to activity_participants_path
   end
 

--- a/app/controllers/activities/registrations_controller.rb
+++ b/app/controllers/activities/registrations_controller.rb
@@ -15,11 +15,19 @@ class Activities::RegistrationsController < ApplicationController
   end
 
   def update
-    @activity
+    registration = @activity
       .registrations
       .find_by(user_id: registration_params[:participant_id])
-      .update_attributes(confirmed: true)
+    registration.update_attribute(:confirmed, !registration.confirmed)
+
     redirect_to activity_participants_path
+  end
+
+  def destroy
+    registration = Registration.find_by(activity_id: @activity.id, user_id: current_user.id)
+    registration.destroy
+
+    redirect_to @activity
   end
 
   private

--- a/app/controllers/activities/registrations_controller.rb
+++ b/app/controllers/activities/registrations_controller.rb
@@ -10,28 +10,28 @@ class Activities::RegistrationsController < ApplicationController
   end
 
   def index
-    @participants = @activity.participants
-    @registrations = @activity.registrations
+    @registrations = @activity.registrations.order('id')
   end
 
   def update
     registration = @activity
       .registrations
       .find_by(user_id: registration_params[:participant_id])
-    registration.update_attribute(:confirmed, !registration.confirmed)
+    registration.update_attribute(:confirmed, registration_params[:confirmed])
+    user = User.find(registration_params[:participant_id])
 
     if registration.confirmed
-      flash[:success] =
-        "Confirmed #{User.find(registration_params[:participant_id]).name}!"
+      flash[:success] ="#{user.name} confirmado!"
     else
-      flash[:alert] =
-        "Canceled #{User.find(registration_params[:participant_id]).name} confirmation!"
+      flash[:alert] = "#{user.name} cancelado!"
     end
+
     redirect_to activity_participants_path
   end
 
   def destroy
-    registration = Registration.find_by(activity_id: @activity.id, user_id: current_user.id)
+    registration = Registration.find_by(activity_id: @activity.id,
+      user_id: current_user.id)
     registration.destroy
 
     redirect_to @activity
@@ -40,7 +40,7 @@ class Activities::RegistrationsController < ApplicationController
   private
 
   def registration_params
-    params.permit(:activity_id, :participant_id)
+    params.permit(:activity_id, :participant_id, :confirmed)
   end
 
   def set_activity

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -1,5 +1,5 @@
 class ActivitiesController < ApplicationController
-  before_action :set_activity, except: [:index]
+  before_action :set_activity, except: [:index, :new, :create]
   load_and_authorize_resource
 
   def new

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -7,7 +7,7 @@ class Ability
       can :manage, [Activity, Registration]
     else
       can :read, Activity
-      can [:read, :create], Registration
+      can [:read, :create, :destroy], Registration
     end
   end
 

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -25,7 +25,7 @@ class Activity < ActiveRecord::Base
   }
 
   def end_date_is_after_start_date
-    if end_date < start_data
+    if end_date < start_date
       errors.add(:end_date, "end_date must occur after start_date")
     end
   end

--- a/app/views/activities/index.slim
+++ b/app/views/activities/index.slim
@@ -1,9 +1,14 @@
 = render partial: 'activities/activities_breadcrumb'
 .divide60
+.container
+  = link_to 'Criar Atividade', new_activity_path, class: 'btn btn-lg btn-update border-theme'
+.divide60
 .container.blog-left-img
+
   - if @activities.empty?
-    h4 Atividades não encontradas
+    p.lead Sem Atividades.
   - @activities.each do |activity|
     = render partial: "shared/activity/index", locals: { activity: activity }
 
   = will_paginate @activities, renderer: BootstrapPagination::Rails
+.divide60

--- a/app/views/activities/registrations/index.slim
+++ b/app/views/activities/registrations/index.slim
@@ -15,17 +15,20 @@
   span.center-line style="margin-bottom: 8px;"
 
   .row
-    - @participants.each_with_index do |participant, index|
+    - @registrations.each do |registration|
+      - participant = registration.user
+
       .col-md-8.col-sm-8.col-xs-12
         h3.lead = link_to participant.name, user_path(participant.id)
       .col-md-4.col-sm-4.col-xs-12
-        - if @registrations[index].confirmed
-          = link_to confirm_participant_path(@activity.id, participant.id),
-            class: "btn btn-disabled pull-right" do
-            i.fa.fa-times.fa-fw
-            | Anular Confirmação
+        - if registration.confirmed
+          = link_to "Anular Confirmação",
+            confirm_participant_path(@activity.id, participant.id, confirmed: false),
+            method: :post,
+            class: "btn btn-disabled pull-right"
         - else
           = link_to "Confirmar",
-            confirm_participant_path(@activity.id, participant.id),
+            confirm_participant_path(@activity.id, participant.id, confirmed: true),
+            method: :post,
             class: "btn border-theme pull-right pull-right"
 .divide20

--- a/app/views/activities/registrations/index.slim
+++ b/app/views/activities/registrations/index.slim
@@ -1,22 +1,31 @@
-= render partial: 'activities/activities_breadcrumb'
+= render partial: "activities/activities_breadcrumb"
 .divide60
 .container
+  - if flash[:success]
+    .row
+      div.alert.alert-success
+        = flash[:success]
+  - elsif flash[:alert]
+    .row
+      div.alert.alert-warning
+        = flash[:alert]
+
   h3.activity-title
     | Participantes
   span.center-line style="margin-bottom: 8px;"
 
   .row
     - @participants.each_with_index do |participant, index|
-      .col-md-10.col-sm-8.col-xs-12
+      .col-md-8.col-sm-8.col-xs-12
         h3.lead = link_to participant.name, user_path(participant.id)
-      .col-md-2.col-sm-4.col-xs-12
+      .col-md-4.col-sm-4.col-xs-12
         - if @registrations[index].confirmed
           = link_to confirm_participant_path(@activity.id, participant.id),
-            class: "btn btn-disabled" do
+            class: "btn btn-disabled pull-right" do
             i.fa.fa-times.fa-fw
             | Anular Confirmação
         - else
-          = link_to 'Confirmar',
+          = link_to "Confirmar",
             confirm_participant_path(@activity.id, participant.id),
-            class: 'btn border-theme pull-right'
+            class: "btn border-theme pull-right pull-right"
 .divide20

--- a/app/views/activities/registrations/index.slim
+++ b/app/views/activities/registrations/index.slim
@@ -4,14 +4,17 @@
   h3.activity-title
     | Participantes
   span.center-line style="margin-bottom: 8px;"
-  
+
   .row
     - @participants.each_with_index do |participant, index|
       .col-md-10.col-sm-8.col-xs-12
         h3.lead = link_to participant.name, user_path(participant.id)
       .col-md-2.col-sm-4.col-xs-12
         - if @registrations[index].confirmed
-          button.btn.btn-disabled.pull-right Confirmado
+          = link_to confirm_participant_path(@activity.id, participant.id),
+            class: "btn btn-disabled" do
+            i.fa.fa-times.fa-fw
+            | Anular Confirmação
         - else
           = link_to 'Confirmar',
             confirm_participant_path(@activity.id, participant.id),

--- a/app/views/activities/show.slim
+++ b/app/views/activities/show.slim
@@ -24,8 +24,10 @@
         - if current_user
           = render partial: "shared/activity/panel", object: @activity
           - if @activity.registered?(current_user)
-            = link_to "Já te encontras inscrito na atividade", "#",
-              class: "btn btn-disabled btn-lg"
+            = link_to activity_registration_cancel_path(@activity.id),
+              class: "btn btn-disabled btn-lg" do
+              i.fa.fa-times.fa-fw
+              | Anular Inscrição
           - else
             - if @activity.end_date.future?
               = link_to "Inscrever-me!",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,9 +3,18 @@ Rails.application.routes.draw do
 
   resources :activities
   scope module: 'activities' do
-    get 'activities/:activity_id/register', to: 'registrations#create', as: 'activity_registration'
-    get 'activities/:activity_id/participants', to: 'registrations#index', as: 'activity_participants'
-    get 'activities/:activity_id/participants/:participant_id', to: 'registrations#update', as: 'confirm_participant'
+    get 'activities/:activity_id/register',
+      to: 'registrations#create',
+      as: 'activity_registration'
+    get 'activities/:activity_id/register_cancel',
+      to: 'registrations#destroy',
+      as: 'activity_registration_cancel'
+    get 'activities/:activity_id/participants',
+      to: 'registrations#index',
+      as: 'activity_participants'
+    get 'activities/:activity_id/participants/:participant_id',
+      to: 'registrations#update',
+      as: 'confirm_participant'
   end
 
   resources :users, only: [:index, :show]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
     get 'activities/:activity_id/participants',
       to: 'registrations#index',
       as: 'activity_participants'
-    get 'activities/:activity_id/participants/:participant_id',
+    post 'activities/:activity_id/participants/:participant_id',
       to: 'registrations#update',
       as: 'confirm_participant'
   end

--- a/db/migrate/20170825233114_add_confirmed_to_registrations.rb
+++ b/db/migrate/20170825233114_add_confirmed_to_registrations.rb
@@ -1,0 +1,5 @@
+class AddConfirmedToRegistrations < ActiveRecord::Migration
+  def change
+    add_column :registrations, :confirmed, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170820181334) do
+ActiveRecord::Schema.define(version: 20170825233114) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -78,8 +78,9 @@ ActiveRecord::Schema.define(version: 20170820181334) do
   create_table "registrations", force: :cascade do |t|
     t.integer  "activity_id"
     t.integer  "user_id"
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
+    t.datetime "created_at",                  null: false
+    t.datetime "updated_at",                  null: false
+    t.boolean  "confirmed",   default: false
   end
 
   create_table "roles", force: :cascade do |t|


### PR DESCRIPTION
### Description

This Pull Request pretends to improve the flow for user registrations, as of right now a user can only register for an activity, but if they clicked on the button without meaning it they have no way of canceling their registration.

On the admin side when an admin confirms the presence of an user on an activity he has no way of reverting that confirmation, which is bad because it might have ben an accident.

This Pull Request tackles those two problems.

### Changes

* Add `confirmed` field to `Registration`.

* Update `activities/show` to show a 'Cancel Registration' button so users can cancel a registration to an activity.

  * Create `destroy` method in `Activities::RegistrationsController`.

* Update `activities/registrations/index` view to display a 'Cancel Registration' button so activitiy admins can cancel confirmations if they ever make a mistake or simply if they need to.

  * Refactor `update` method of `Activities::RegistrationControoler` to simply reverse the `confirmed` field, allowing this method to be used for confirmation and denial of a user presence in a activity.