### PR TITLE
Update faker gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,7 +97,7 @@ GEM
     factory_girl_rails (4.5.0)
       factory_girl (~> 4.5.0)
       railties (>= 3.0.0)
-    faker (1.4.3)
+    faker (1.8.4)
       i18n (~> 0.5)
     faraday (0.10.1)
       multipart-post (>= 1.2, < 3)
@@ -107,7 +107,7 @@ GEM
       activesupport (>= 4.1.0)
     google-analytics-rails (1.1.0)
     hashie (3.5.1)
-    i18n (0.7.0)
+    i18n (0.8.6)
     jquery-rails (4.0.5)
       rails-dom-testing (~> 1.0)
       railties (>= 4.2.0)
@@ -316,4 +316,4 @@ DEPENDENCIES
   wow-rails
 
 BUNDLED WITH
-   1.14.6
+   1.15.4


### PR DESCRIPTION
We are using a module of faker that does not exist in the version we are using. This just updates the gem.