### PR TITLE
Improve Activity Registrations 

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -3,12 +3,15 @@ class Ability
 
   def initialize(user)
     user ||= User.new # guest user (not logged in)
-    if user.activity_admin?
-      can :manage, [Activity, Registration]
-    else
+
+    case user.permissions
+    when :guest
       can :read, Activity
-      can [:read, :create], Registration
+    when :user
+      can :read, Activity
+      can [:create, :destroy], Registration, user_id: user.id
+    when :activity_admin
+      can :manage, [Activity, Registration]
     end
   end
-
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,6 +20,12 @@ class User < ActiveRecord::Base
     self.member && self.member.activity_admin
   end
 
+  def permissions
+    return :guest unless self.persisted?
+    return :user unless self.activity_admin?
+    return :activity_admin
+  end
+
   private
 
   def self.find_or_create_from_omniauth(auth)

--- a/app/views/activities/_registration.slim
+++ b/app/views/activities/_registration.slim
@@ -1,0 +1,10 @@
+- if @activity.end_date.future?
+  - if can?(:destroy, Registration) && @activity.registered?(current_user)
+    = link_to activity_registration_cancel_path(@activity.id),
+      class: "btn btn-disabled btn-lg" do
+      i.fa.fa-times.fa-fw
+      | Anular Inscrição
+  - elsif can?(:create, Registration)
+    = link_to "Inscrever-me!",
+      activity_registration_path(@activity) || "#",
+      class: "btn border-theme btn-lg" + (@activity.end_date.past? ? " disabled": "")

--- a/app/views/activities/registrations/index.slim
+++ b/app/views/activities/registrations/index.slim
@@ -1,19 +1,32 @@
-= render partial: 'activities/activities_breadcrumb'
+= render partial: "activities/activities_breadcrumb"
 .divide60
 .container
+  - if flash[:success]
+    .row
+      div.alert.alert-success
+        = flash[:success]
+  - elsif flash[:alert]
+    .row
+      div.alert.alert-warning
+        = flash[:alert]
+
   h3.activity-title
     | Participantes
   span.center-line style="margin-bottom: 8px;"
-  
+
   .row
-    - @participants.each_with_index do |participant, index|
-      .col-md-10.col-sm-8.col-xs-12
+    - @registrations.each do |registration|
+      - participant = registration.user
+
+      .col-md-8.col-sm-8.col-xs-12
         h3.lead = link_to participant.name, user_path(participant.id)
-      .col-md-2.col-sm-4.col-xs-12
-        - if @registrations[index].confirmed
-          button.btn.btn-disabled.pull-right Confirmado
-        - else
-          = link_to 'Confirmar',
-            confirm_participant_path(@activity.id, participant.id),
-            class: 'btn border-theme pull-right'
+      .col-md-4.col-sm-4.col-xs-12
+        = form_for registration,
+          url: confirm_participant_path(@activity.id, participant.id) do |f|
+
+          = hidden_field_tag :confirmed, registration.confirmed
+          - if registration.confirmed
+            = f.button "Anular confirmação", class: "btn btn-disabled pull-right"
+          - else
+            = f.button "Confirmar", class: "btn border-theme pull-right pull-right"
 .divide20

--- a/app/views/activities/show.slim
+++ b/app/views/activities/show.slim
@@ -13,30 +13,19 @@
       .col-md-7
         = simple_format(@activity.description, class: "lead")
         = render partial: "shared/activity/panel", object: @activity
-        = link_to "Inscrever-me!",
-          activity_registration_path(@activity) || "#",
-          class: "btn btn-theme-dark btn-lg" + (@activity.end_date.past? ? " disabled": ""),
-          target: "_blank"
+        = render partial: "registration", object: @activity
     - else
       .col-md-6
         = simple_format(@activity.description, class: "lead")
       .col-md-6
-        - if current_user
-          = render partial: "shared/activity/panel", object: @activity
-          - if @activity.registered?(current_user)
-            = link_to "Já te encontras inscrito na atividade", "#",
-              class: "btn btn-disabled btn-lg"
-          - else
-            - if @activity.end_date.future?
-              = link_to "Inscrever-me!",
-                activity_registration_path(@activity.id),
-                class: 'btn border-theme btn-lg'
-        hr
-        - if current_user && current_user.activity_admin?
-          = link_to "Participantes",
-            activity_participants_path(@activity.id),
-            class: 'btn border-theme btn-lg'
-        - if can? :edit, Activity
-          = link_to "Editar", edit_activity_path,
-            class: 'btn border-theme btn-lg btn-edit'
+        = render partial: "shared/activity/panel", object: @activity
+        = render partial: "registration", object: @activity
+
+  hr
+  - if can? :index, Registration
+    = link_to "Participantes", activity_participants_path(@activity.id),
+      class: 'btn border-theme btn-lg'
+  - if can? :edit, Activity
+    = link_to "Editar", edit_activity_path, class: 'btn border-theme btn-lg btn-edit'
+
 .divide20

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,9 +3,18 @@ Rails.application.routes.draw do
 
   resources :activities
   scope module: 'activities' do
-    get 'activities/:activity_id/register', to: 'registrations#create', as: 'activity_registration'
-    get 'activities/:activity_id/participants', to: 'registrations#index', as: 'activity_participants'
-    get 'activities/:activity_id/participants/:participant_id', to: 'registrations#update', as: 'confirm_participant'
+    get 'activities/:activity_id/register',
+      to: 'registrations#create',
+      as: 'activity_registration'
+    get 'activities/:activity_id/register_cancel',
+      to: 'registrations#destroy',
+      as: 'activity_registration_cancel'
+    get 'activities/:activity_id/participants',
+      to: 'registrations#index',
+      as: 'activity_participants'
+    patch 'activities/:activity_id/participants/:participant_id',
+      to: 'registrations#update',
+      as: 'confirm_participant'
   end
 
   resources :users, only: [:index, :show]

--- a/db/migrate/20170825233114_add_confirmed_to_registrations.rb
+++ b/db/migrate/20170825233114_add_confirmed_to_registrations.rb
@@ -1,0 +1,5 @@
+class AddConfirmedToRegistrations < ActiveRecord::Migration
+  def change
+    add_column :registrations, :confirmed, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170820181334) do
+ActiveRecord::Schema.define(version: 20170825233114) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -78,8 +78,9 @@ ActiveRecord::Schema.define(version: 20170820181334) do
   create_table "registrations", force: :cascade do |t|
     t.integer  "activity_id"
     t.integer  "user_id"
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
+    t.datetime "created_at",                  null: false
+    t.datetime "updated_at",                  null: false
+    t.boolean  "confirmed",   default: false
   end
 
   create_table "roles", force: :cascade do |t|


### PR DESCRIPTION
I create a branch from https://github.com/cesium/atomic/pull/85 to fix the last issues. My changes on @joaofcosta branch are:

- change the registration#update action to make it idempotent
- fix an issue where users could cancel their registration
- extract the logic from a view to a partial

**In case you review changes per commit:** the registration controller changes where supposed to be added in commit deb562d and not in 181f43d.
