### PR TITLE
Adds meta tags to activities

### DIFF
--- a/app/views/activities/show.slim
+++ b/app/views/activities/show.slim
@@ -1,4 +1,10 @@
 = render partial: 'activities/activities_breadcrumb'
+
+- content_for :head do
+  meta property='og:image' content='#{@activity.poster.url}'
+  meta property='og:title' content='#{@activity.name}'
+  meta property='og:description' content='#{truncate(@activity.description, length: 140)}'
+
 .divide60
 .container
   h3.activity-title

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -8,6 +8,9 @@ html
 
     title CeSIUM Centro de Estudantes
     = analytics_init if GoogleAnalytics.valid_tracker?
+
+    - if content_for?(:head)
+      = yield(:head)
   body
     #flash
       - flash.each do |key, value|


### PR DESCRIPTION
This PR adds meta tags to each activity, this way the activity's link can be shared on other websites so that they preview the activity's poster, title and description. The description is limited to 140 characters. 