### PR TITLE
Add more registration options

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -48,7 +48,7 @@ class ActivitiesController < ApplicationController
   def activity_params
     params.require(:activity).permit(:name, :location, :description,
       :total_rating, :member_cost, :guest_cost, :start_date, :end_date,
-      :coffee_break, :poster, :department_id)
+      :coffee_break, :poster, :department_id, :allows_registrations, :external_link)
   end
 
     def previous_activities_requested?

--- a/app/helpers/activities_helper.rb
+++ b/app/helpers/activities_helper.rb
@@ -1,4 +1,14 @@
 module ActivitiesHelper
+  def can_cancel_registratation?(activity)
+    registration = activity.registrations.build
+    can?(:destroy, registration) && activity.registered?(current_user)
+  end
+
+  def can_registrate?(activity)
+    registration = @activity.registrations.build
+    can?(:create, registration) && !activity.registered?(current_user)
+  end
+
   def can_create?
     can? :create, Activity
   end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -5,16 +5,30 @@ class Ability
     user ||= User.new # guest user (not logged in)
 
     case user.permissions
-    when :guest
-      can :read, Activity
-    when :user
-      can :read, Activity
-      can [:create, :destroy], Registration, user_id: user.id
-    when :activity_admin
-      can :manage, [Activity, Registration]
+    when :guest then guest_permissions(user)
+    when :user then user_permissions(user)
+    when :activity_admin then activity_admin_permissions(user)
     end
 
+  end
+
+  private
+
+  def guest_permissions(user)
+    can :read, Activity
     can :destroy, :session if user.persisted?
     can [:read, :create], :session unless user.persisted?
+  end
+
+  def user_permissions(user)
+    guest_permissions(user)
+    can :destroy, Registration
+    can :create, Registration, activity: { allows_registrations: true }
+  end
+
+  def activity_admin_permissions(user)
+    user_permissions(user)
+    can :manage, Activity
+    can [:index, :update], Registration
   end
 end

--- a/app/views/activities/_form.slim
+++ b/app/views/activities/_form.slim
@@ -79,6 +79,20 @@
     {include_blank: 'None'}
   br
 
+  = form.label :external_link,
+    class: "activity-form-label"
+  br
+  = form.text_field :external_link,
+    class: "activity-form-field"
+  br
+
+  = form.label :allows_registrations,
+    class: "activity-form-label"
+  = form.check_box :allows_registrations,
+    class: "activity-form-field"
+  br
+  br
+
   = form.label :poster,
     class: "activity-form-label"
   br

--- a/app/views/activities/_registration.slim
+++ b/app/views/activities/_registration.slim
@@ -1,10 +1,15 @@
-- if @activity.end_date.future?
-  - if can?(:destroy, Registration) && @activity.registered?(current_user)
+- if @activity.external_link.empty?
+  - if can_cancel_registratation?(@activity)
     = link_to activity_registration_cancel_path(@activity.id),
       class: "btn btn-disabled btn-lg" do
       i.fa.fa-times.fa-fw
       | Anular Inscrição
-  - elsif can?(:create, Registration)
+  - elsif can_registrate?(@activity)
     = link_to "Inscrever-me!",
       activity_registration_path(@activity) || "#",
-      class: "btn border-theme btn-lg" + (@activity.end_date.past? ? " disabled": "")
+      class: "btn border-theme btn-lg"
+- elsif can_registrate?(@activity)
+  = link_to "Inscrever-me!",
+    @activity.external_link,
+    class: "btn border-theme btn-lg",
+    target: '_blank'

--- a/app/views/activities/show.slim
+++ b/app/views/activities/show.slim
@@ -12,7 +12,8 @@
     .col-md-7
       = simple_format(@activity.description, class: "lead")
       = render partial: "shared/activity/panel", object: @activity
-      = render partial: "registration", object: @activity
+      - if @activity.end_date.future?
+        = render partial: "registration", object: @activity
 
   hr
   - if can? :index, Registration

--- a/db/migrate/20171013085029_add_registration_options_to_activities.rb
+++ b/db/migrate/20171013085029_add_registration_options_to_activities.rb
@@ -1,0 +1,6 @@
+class AddRegistrationOptionsToActivities < ActiveRecord::Migration
+  def change
+    add_column :activities, :allows_registrations, :boolean, default: true
+    add_column :activities, :external_link, :string, default: ""
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,18 +11,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170825233114) do
+ActiveRecord::Schema.define(version: 20171013085029) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "activities", force: :cascade do |t|
-    t.string   "name",                limit: 75
+    t.string   "name",                 limit: 75
     t.string   "location"
     t.text     "description"
     t.integer  "total_rating"
-    t.decimal  "member_cost",                    precision: 5, scale: 2
-    t.decimal  "guest_cost",                     precision: 5, scale: 2
+    t.decimal  "member_cost",                     precision: 5, scale: 2
+    t.decimal  "guest_cost",                      precision: 5, scale: 2
     t.datetime "start_date"
     t.datetime "end_date"
     t.boolean  "coffee_break"
@@ -31,9 +31,11 @@ ActiveRecord::Schema.define(version: 20170825233114) do
     t.integer  "poster_file_size"
     t.datetime "poster_updated_at"
     t.integer  "activity_id"
-    t.datetime "created_at",                                             null: false
-    t.datetime "updated_at",                                             null: false
+    t.datetime "created_at",                                                             null: false
+    t.datetime "updated_at",                                                             null: false
     t.integer  "department_id"
+    t.boolean  "allows_registrations",                                    default: true
+    t.string   "external_link",                                           default: ""
   end
 
   add_index "activities", ["activity_id"], name: "index_activities_on_activity_id", using: :btree


### PR DESCRIPTION
This PR adds two new columns to an activity:

- **external_link**: allows the admins to specify an external registration platform in case they need to use a more complex process (ex: doodle)

- **allows_registrations**: the admins can now specify if the users can start signing up for the activity or not. This allows the admins to announce an event earlier even if they still don't know exactly when will it happen.