### PR TITLE
Make login and activity registration more noticeable

### DIFF
--- a/app/assets/stylesheets/landing_page/_header.scss
+++ b/app/assets/stylesheets/landing_page/_header.scss
@@ -45,6 +45,18 @@
     height: auto;
 }
 
+.btn-login {
+  color: $color-skin !important;
+  font-weight: bold !important;
+  padding-left: 20px !important;
+  padding-right: 20px !important;
+  margin-left: 20px;
+}
+
+.btn-login:hover {
+  color: #fff !important;
+  background-color: $color-skin !important;
+}
 /*============================*/
 /*======dropdowm menu=========*/
 /*============================*/
@@ -74,6 +86,7 @@
 .dropdown-menu .label{
     margin-top: 6px;
 }
+
 .navbar .dropdown-menu li a:hover{
     background-color: #f5f5f5;
 }
@@ -491,5 +504,8 @@ TOP BARS
             }
         }
     }
-}
 
+    .btn-login  {
+      margin-left: 0px;
+    }
+}

--- a/app/helpers/activities_helper.rb
+++ b/app/helpers/activities_helper.rb
@@ -19,6 +19,16 @@ module ActivitiesHelper
     can?(:create, registration) && !activity.registered?(current_user)
   end
 
+  def activity_link(activity)
+    if current_user.nil?
+      sign_in_path
+    elsif activity.external_link.empty?
+      activity_registration_path(@activity)
+    else
+      @activity.external_link
+    end
+  end
+
   def can_create?
     can? :create, Activity
   end

--- a/app/views/activities/_registration.slim
+++ b/app/views/activities/_registration.slim
@@ -1,15 +1,9 @@
-- if @activity.external_link.empty?
-  - if can_cancel_registratation?(@activity)
-    = link_to activity_registration_cancel_path(@activity.id),
-      class: "btn btn-disabled btn-lg" do
-      i.fa.fa-times.fa-fw
-      | Anular Inscrição
-  - elsif can_registrate?(@activity)
-    = link_to "Inscrever-me!",
-      activity_registration_path(@activity) || "#",
-      class: "btn border-theme btn-lg"
-- elsif can_registrate?(@activity)
+- if can_cancel_registratation?(@activity)
+  = link_to activity_registration_cancel_path(@activity.id),
+    class: "btn btn-disabled btn-lg" do
+    i.fa.fa-times.fa-fw
+    | Anular Inscrição
+- elsif current_user.nil? || can_registrate?(@activity)
   = link_to "Inscrever-me!",
-    @activity.external_link,
-    class: "btn border-theme btn-lg",
-    target: '_blank'
+    activity_link(@activity) || '#',
+    class: "btn border-theme btn-lg"

--- a/app/views/layouts/lp/_navbar.html.slim
+++ b/app/views/layouts/lp/_navbar.html.slim
@@ -31,4 +31,5 @@
             = link_to 'Log Out', sign_out_path, method: :delete
         - else
           li
-            = link_to 'Log In', sign_in_path
+            = link_to 'Log In', sign_in_path,
+              class: 'btn border-theme btn-login'


### PR DESCRIPTION
This PR aims to enhance UI/UX by making the login button more noticeable and draw attention to the fact that is possible to register in activities. Since you need to be logged in to show the 'register' button, people were not noticing it.

This PR should:
- [X] Make the 'login' button more noticeable
- [X] Make the 'register' button always present
- [ ] If the user isn't logged in, the 'register' button should redirect to the sign in page and, after a successful login, the user is redirected to the activity page.
- [ ] The 'logout' button should be replaced with the user image.
- [ ] The user image, once clicked, should present a dropdown menu with the option 'logout'
