### PR TITLE
Removed "text-transform: capitalize" for h3.heading.

### DIFF
--- a/app/assets/stylesheets/landing_page/_base.scss
+++ b/app/assets/stylesheets/landing_page/_base.scss
@@ -113,7 +113,6 @@ h3.heading{
     margin: 0 0 20px;
     padding-bottom: 10px;
     position: relative;
-    text-transform: capitalize;
     overflow: hidden;
     vertical-align: middle;
     font-family: $primary-font;


### PR DESCRIPTION
"Departamento de Relações Externas e Parcerias" instead of "Departamento De Relações Externas E Parcerias". 😁

By the way, I searched for other h3.heading usages but haven't found any. So, I'm pretty sure that it's only used for department's name header in team's section.