### PR TITLE
Add /public/system to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 !/log/.keep
 /tmp
 logfile
+/public/system
 
 # Vim
 *~


### PR DESCRIPTION
Images that are uploaded for activities during development are not ignored by git.