### PR TITLE
Enhance Logout Button

### DIFF
--- a/app/assets/stylesheets/landing_page/_header.scss
+++ b/app/assets/stylesheets/landing_page/_header.scss
@@ -38,11 +38,25 @@
 }
 .navbar-default .navbar-nav>li>a:hover {
     color: $color-skin;
-
 }
+
+.nav .open > a, .nav .open > a:hover, .nav .open > a:focus {
+  background-color: #eeeeee;
+  border-color: #f1f1f1;
+}
+
 .navbar-brand img{
-    width:150px;
+    width: 150px;
     height: auto;
+}
+
+.navbar-user {
+    height: 50px;
+}
+
+.navbar-signout {
+    padding: 0px;
+    margin-left: 20px;
 }
 
 .btn-login {

--- a/app/views/layouts/lp/_logout_button.html.slim
+++ b/app/views/layouts/lp/_logout_button.html.slim
@@ -1,0 +1,13 @@
+.dropdown.show
+  = link_to image_tag(current_user.image, class: 'img-circle navbar-user'), '#',
+    id: 'dropdownMenuLink',
+    class: 'btn dropdown-toggle navbar-signout',
+    aria: {haspopup: 'true'},
+    data: {toggle: 'dropdown'}
+  ul.dropdown-menu aria-labelledby='dropdownMenuLink'
+    li
+      = link_to 'Meu Perfil', user_path(current_user), class: 'dropdown-item'
+    li
+      .dropdown-divider
+    li
+      = link_to 'Sign Out', sign_out_path, class: 'dropdown-item', method: :delete

--- a/app/views/layouts/lp/_navbar.html.slim
+++ b/app/views/layouts/lp/_navbar.html.slim
@@ -28,7 +28,7 @@
           = link_to 'CONTACTOS', contact_path
         - if current_user
           li
-            = link_to 'Log Out', sign_out_path, method: :delete
+            = render 'layouts/lp/logout_button'
         - else
           li
             = link_to 'Log In', sign_in_path,

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -19,7 +19,6 @@ ActiveRecord::Schema.define(version: 20180430193811) do
     t.string "name", limit: 75
     t.string "location"
     t.text "description"
-    t.string "speaker", limit: 75
     t.integer "total_rating"
     t.decimal "member_cost", precision: 5, scale: 2
     t.decimal "guest_cost", precision: 5, scale: 2


### PR DESCRIPTION
This PR aims to enhance the logout button on navbar's top right hand corner. 
Currently, when a user logs in, the only change visible is the navbar's top right hand corner which shows a new "logout" button. There is no real sense of which user is loged in and there's no way to get to his public profile page.
Thus, this PR will replace the logout button with the user's image. This image is a dropdown menu with two options: check the profile page and "log out". 