### PR TITLE
Fix: adding a poster depends on registrations being allowed

### DIFF
--- a/app/views/activities/_form.slim
+++ b/app/views/activities/_form.slim
@@ -98,12 +98,12 @@
       = form.number_field :number_participants,
         value: 20,
         class: "activity-form-field"
-    br
-    = form.label :poster,
-      class: "activity-form-label"
-    br
-    = form.file_field :poster,
-      class: "activity-form-field"
+  br
+  = form.label :poster,
+    class: "activity-form-label"
+  br
+  = form.file_field :poster,
+    class: "activity-form-field"
   br
 
   .submit-field


### PR DESCRIPTION
Adding a poster to an activity was only allowed if registrations were also allowed. This is a fix for that.