### PR TITLE
Fix missing secrets for staging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ addons:
 services: postgresql
 
 install:
-  - bundle install --path vendor/bundle
+  - bundle config set --local path 'vendor/bundle'
+  - bundle install
   - bin/setup
 
 script:

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,9 @@ gem "rails", "5.1.4"
 gem "dotenv"
 gem "dotenv-rails", require: "dotenv/rails-now"
 
+# Temporary fix
+gem "mimemagic", github: "mimemagicrb/mimemagic", ref: "01f92d86d15d85cfd0f20dabd025dcbd36a8a60f"
+
 gem "google-analytics-rails", "1.1.0"
 gem "jquery-rails"
 gem "jquery-ui-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,13 @@ GIT
       capistrano (~> 3.1)
       sshkit (~> 1.3)
 
+GIT
+  remote: https://github.com/mimemagicrb/mimemagic.git
+  revision: 01f92d86d15d85cfd0f20dabd025dcbd36a8a60f
+  ref: 01f92d86d15d85cfd0f20dabd025dcbd36a8a60f
+  specs:
+    mimemagic (0.3.5)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -133,7 +140,7 @@ GEM
     mime-types (3.2.2)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2018.0812)
-    mimemagic (0.3.2)
+    mimemagic (0.3.5)
     mini_mime (1.0.1)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
@@ -338,6 +345,7 @@ DEPENDENCIES
   jquery-rails
   jquery-ui-rails
   listen
+  mimemagic!
   omniauth-github
   omniauth-google-oauth2
   owlcarousel-rails


### PR DESCRIPTION
puma_error.log

```
#<RuntimeError: Missing `secret_key_base` for 'staging' environment, set this value in `config/secrets.yml`>
/usr/share/nginx/atomic-staging/shared/bundle/ruby/2.4.0/gems/railties-5.1.4/lib/rails/application.rb:510:in `validate_secret_key_config!'
/usr/share/nginx/atomic-staging/shared/bundle/ruby/2.4.0/gems/railties-5.1.4/lib/rails/application.rb:247:in `env_config'
/usr/share/nginx/atomic-staging/shared/bundle/ruby/2.4.0/gems/railties-5.1.4/lib/rails/engine.rb:692:in `build_request'
/usr/share/nginx/atomic-staging/shared/bundle/ruby/2.4.0/gems/railties-5.1.4/lib/rails/application.rb:518:in `build_request'
/usr/share/nginx/atomic-staging/shared/bundle/ruby/2.4.0/gems/railties-5.1.4/lib/rails/engine.rb:521:in `call'
/usr/share/nginx/atomic-staging/shared/bundle/ruby/2.4.0/gems/puma-3.12.0/lib/puma/configuration.rb:225:in `call'
/usr/share/nginx/atomic-staging/shared/bundle/ruby/2.4.0/gems/puma-3.12.0/lib/puma/server.rb:658:in `handle_request'
/usr/share/nginx/atomic-staging/shared/bundle/ruby/2.4.0/gems/puma-3.12.0/lib/puma/server.rb:472:in `process_client'
/usr/share/nginx/atomic-staging/shared/bundle/ruby/2.4.0/gems/puma-3.12.0/lib/puma/server.rb:332:in `block in run'
/usr/share/nginx/atomic-staging/shared/bundle/ruby/2.4.0/gems/puma-3.12.0/lib/puma/thread_pool.rb:133:in `block in spawn_thread'
=== puma startup: 2021-04-23 15:31:36 +0100 ===

```