### PR TITLE
Revert to Ruby 2.7.5 to maintain 'Paperclip' dependency

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-ruby 3.0.3
+ruby 2.7.5
 nodejs 16.13.0

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+ruby '2.7.5'
+
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -434,5 +434,8 @@ DEPENDENCIES
   will_paginate-bootstrap
   wow-rails
 
+RUBY VERSION
+   ruby 2.7.5p203
+
 BUNDLED WITH
-   2.3.0
+   2.3.5


### PR DESCRIPTION
`Paperclip` was used to store and manage uploaded images before Rail's Active Storage came along.

Turns out, `Paperclip` was deprecated shortly after the release of Active Storage and it does not support Ruby 3.

Migrating to our records to Active Storage is the long term solution, but the documentation is sparse and I've been at it for a few hours with moderate success, but unfortunately not enough.

So, for the time being, let's revert to Ruby 2.7.5 so we have a functioning site and think about migrations later.