### PR TITLE
fix: enrollments update

### DIFF
--- a/lib/atomic/activities.ex
+++ b/lib/atomic/activities.ex
@@ -430,7 +430,7 @@ defmodule Atomic.Activities do
   """
   def update_enrollment(%Enrollment{} = enrollment, attrs) do
     enrollment
-    |> Enrollment.changeset(attrs)
+    |> Enrollment.update_changeset(attrs)
     |> Repo.update()
   end
 

--- a/lib/atomic/activities/enrollment.ex
+++ b/lib/atomic/activities/enrollment.ex
@@ -27,10 +27,14 @@ defmodule Atomic.Activities.Enrollment do
     |> validate_required(@required_fields)
   end
 
-  @doc """
-    Validates if the maximum number of enrollments has been reached.
-  """
-  def validate_maximum_entries(changeset) do
+  def update_changeset(enrollment, attrs) do
+    enrollment
+    |> cast(attrs, @required_fields ++ @optional_fields)
+    |> validate_required(@required_fields)
+  end
+
+  # Validates if the maximum number of enrollments has been reached.
+  defp validate_maximum_entries(changeset) do
     session_id = get_field(changeset, :session_id)
     session = Activities.get_session!(session_id)
     enrolled = Activities.get_total_enrolled(session.id)


### PR DESCRIPTION
Before: updating an enrollment was failing when the maximum number of enrollments had been reached.
Now: updating an enrollment (such as setting its presence to true) is working as intended.