### PR TITLE
chore: remove deprecated version field from docker compose config

### DIFF
--- a/darwin.yml
+++ b/darwin.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   db:
     ports:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   db:
     image: postgres:14.1

--- a/linux.yml
+++ b/linux.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   db:
     network_mode: "host"


### PR DESCRIPTION
Recent versions of the `docker compose` command have deprecated the `version` field within configuration files. This PR intends to remove those fields. That way, we will now also see some warnings disappear, when running such commands 😄