### PR TITLE
fix: text overflow in announcements and activities on the main page

### DIFF
--- a/lib/atomic_web/components/activity.ex
+++ b/lib/atomic_web/components/activity.ex
@@ -32,7 +32,7 @@ defmodule AtomicWeb.Components.Activity do
         </div>
       </div>
       <h2 class="mt-3 text-base font-semibold text-zinc-900"><%= @activity.title %></h2>
-      <div class="text-justify text-sm text-zinc-700">
+      <div class="overflow-hidden break-words text-justify text-sm text-zinc-700">
         <p><%= maybe_slice_string(@activity.description, 300) %></p>
       </div>
       <!-- Image -->

--- a/lib/atomic_web/components/announcement.ex
+++ b/lib/atomic_web/components/announcement.ex
@@ -30,7 +30,7 @@ defmodule AtomicWeb.Components.Announcement do
         </div>
       </div>
       <h2 class="mt-3 text-base font-semibold text-zinc-900"><%= @announcement.title %></h2>
-      <div class="space-y-4 text-justify text-sm text-zinc-700">
+      <div class="space-y-4 text-justify text-sm text-zinc-700 overflow-hidden break-words">
         <%= maybe_slice_string(@announcement.description, 300) %>
       </div>
       <!-- Image -->

--- a/lib/atomic_web/components/announcement.ex
+++ b/lib/atomic_web/components/announcement.ex
@@ -30,7 +30,7 @@ defmodule AtomicWeb.Components.Announcement do
         </div>
       </div>
       <h2 class="mt-3 text-base font-semibold text-zinc-900"><%= @announcement.title %></h2>
-      <div class="space-y-4 text-justify text-sm text-zinc-700 overflow-hidden break-words">
+      <div class="space-y-4 overflow-hidden break-words text-justify text-sm text-zinc-700">
         <%= maybe_slice_string(@announcement.description, 300) %>
       </div>
       <!-- Image -->


### PR DESCRIPTION
Text was overflowing if the description of the announcement or activity was too big

![image](https://github.com/user-attachments/assets/15f65af2-a975-48a4-aeda-a4789e3c0dc2)
