### PR TITLE
fix: scanner breaking if permission to use the camera is denied/blocked

### DIFF
--- a/assets/js/hooks/qr_reading.js
+++ b/assets/js/hooks/qr_reading.js
@@ -14,8 +14,9 @@ function parseURL(url) {
 export const QrScanner = {
 
   mounted() {
-    const config = { fps: 4, qrbox: (width, height) => {return { width: width * 0.8, height: height * 0.9 }}};
-    this.scanner = new Html5Qrcode(this.el.id, { formatsToSupport: [ Html5QrcodeSupportedFormats.QR_CODE ] });
+    const config = { fps: 4, qrbox: (width, height) => { return { width: width * 0.8, height: height * 0.9 } } };
+    this.scanner = new Html5Qrcode(this.el.id, { formatsToSupport: [Html5QrcodeSupportedFormats.QR_CODE] });
+    this.isScanning = false;
 
     const onScanSuccess = (decodedText, decodedResult) => {
       const pathname = parseURL(decodedText);
@@ -28,13 +29,16 @@ export const QrScanner = {
 
     const startScanner = () => {
       this.scanner.start({ facingMode: "environment" }, config, onScanSuccess)
-      .then((_) => {
-        if (this.el.dataset.on_start)
-          Function("hook", this.el.dataset.on_start)(this);
-      }, (e) => {
-        if (this.el.dataset.on_error)
-          Function("hook", this.el.dataset.on_error)(this);
-      });
+        .then((_) => {
+          this.isScanning = true;
+          if (this.el.dataset.on_start)
+            Function("hook", this.el.dataset.on_start)(this);
+        })
+        .catch((e) => {
+          this.isScanning = false;
+          if (this.el.dataset.on_error)
+            Function("hook", this.el.dataset.on_error)(this);
+        });
     }
 
     if (this.el.dataset.ask_perm) {
@@ -46,9 +50,13 @@ export const QrScanner = {
   },
 
   destroyed() {
-    this.scanner.stop().then((_) => {
-      if (this.el.dataset.on_stop)
-        Function("hook", this.el.dataset.on_stop)(this);
-    });
+    if (this.isScanning) {
+      this.scanner.stop().then((_) => {
+        if (this.el.dataset.on_stop)
+          Function("hook", this.el.dataset.on_stop)(this);
+      }).catch((e) => {
+        console.warn("Failed to stop the scanner:", e);
+      });
+    }
   }
 }


### PR DESCRIPTION
#539 

If the permission to use the camera was denied in the scanner page then the user would not be able to go to any other page of the application (only after a f5 was it possible) because an error occurred due to a missing check in the scanner's logic.

![image](https://github.com/user-attachments/assets/886dab3b-3b0e-4231-8175-103d962685b2)

